### PR TITLE
Rca 320/21

### DIFF
--- a/Insolvency.CalculationsEngine.Redundancy.BL.UnitTests/TestData/RedundancyPaymentTestDataHelper.cs
+++ b/Insolvency.CalculationsEngine.Redundancy.BL.UnitTests/TestData/RedundancyPaymentTestDataHelper.cs
@@ -53,7 +53,7 @@ namespace Insolvency.CalculationsEngine.Redundancy.BL.UnitTests.TestData
                    new RedundancyPaymentCalculationRequestModel(
                     new DateTime(2011,04,14), new DateTime(2016,04,14), new DateTime(2016,02,13),
                     new DateTime(1995,04,14), 257m, 102.35m, 0),
-                   new RedundancyPaymentResponseDto(new DateTime(2011,04,14), 4,new DateTime(2016,04,14), 5, 0, 0, 2.5m, 540.15m, 102.35m, 540.15m)
+                   new RedundancyPaymentResponseDto(new DateTime(2011,04,14), 4,new DateTime(2016,04,14), 5, 0, 0, 2.5m, 642.5m, 102.35m, 540.15m)
                 };
 
                 yield return new object[]
@@ -62,7 +62,7 @@ namespace Insolvency.CalculationsEngine.Redundancy.BL.UnitTests.TestData
                    new RedundancyPaymentCalculationRequestModel(
                     new DateTime(1997,10,1), new DateTime(2018,10,1), new DateTime(2018,10,1),
                     new DateTime(1956,9,1), 300m, 10000m, 0),
-                   new RedundancyPaymentResponseDto(new DateTime(1997,10,1), 12, new DateTime(2018,12,24), 0, 0, 20, 30m, 0m, 10000m, 0m)
+                   new RedundancyPaymentResponseDto(new DateTime(1997,10,1), 12, new DateTime(2018,12,24), 0, 0, 20, 30m, 9000m, 10000m, 0m)
                 };
             }
             IEnumerator IEnumerable.GetEnumerator()

--- a/Insolvency.CalculationsEngine.Redundancy.BL/DTOs/RedundancyPayment/RedundancyPaymentResponseDTO.cs
+++ b/Insolvency.CalculationsEngine.Redundancy.BL/DTOs/RedundancyPayment/RedundancyPaymentResponseDTO.cs
@@ -33,5 +33,6 @@ namespace Insolvency.CalculationsEngine.Redundancy.BL.DTOs.RedundancyPayment
         public decimal NetEntitlement { get; set; }
         public decimal PreferentialClaim { get; set; }
         public decimal NonPreferentialClaim { get; set; }
+        public decimal StatutoryMaximum { get; set; }
     }
 }

--- a/Insolvency.CalculationsEngine.Redundancy.BL/Services/Implementations/RedundancyPaymentCalculationService.cs
+++ b/Insolvency.CalculationsEngine.Redundancy.BL/Services/Implementations/RedundancyPaymentCalculationService.cs
@@ -62,6 +62,10 @@ namespace Insolvency.CalculationsEngine.Redundancy.BL.Services.Implementations
             var redundancyPayWeeks = decimal.Multiply(yearsOfServiceUpto21 , 0.5m) + yearsOfService22To41 + decimal.Multiply(yearsOfServiceOver41, 1.5m);
             var grossEntitlement = redundancyPayWeeks * appliedRateOfPay;
 
+            var grossEntitlementFinal = Math.Max(0m, Math.Round(grossEntitlement, 2));
+            var employerPartPaymentFinal = Math.Round(data.EmployerPartPayment, 2);
+            var netEntitlementFinal = Math.Max(0m, (grossEntitlementFinal - employerPartPaymentFinal));
+
             calculationResult.AdjEmploymentStartDate = adjStartDate;
             calculationResult.NoticeDateForRedundancyPay = relevantDismissalDate;
             calculationResult.NoticeEntitlementWeeks = noticeEntitlementWeeks;
@@ -69,11 +73,12 @@ namespace Insolvency.CalculationsEngine.Redundancy.BL.Services.Implementations
             calculationResult.YearsOfServiceUpto21 = yearsOfServiceUpto21;
             calculationResult.YearsOfServiceFrom22To41 = yearsOfService22To41;
             calculationResult.YearsServiceOver41 = yearsOfServiceOver41;
-            calculationResult.GrossEntitlement = Math.Max(0m, Math.Round(grossEntitlement, 2) - Math.Round(data.EmployerPartPayment, 2));
-            calculationResult.EmployerPartPayment = Math.Round(data.EmployerPartPayment, 2);
-            calculationResult.NetEntitlement = Math.Max(0m, Math.Round(grossEntitlement, 2) - Math.Round(data.EmployerPartPayment, 2));
+            calculationResult.GrossEntitlement = grossEntitlementFinal;
+            calculationResult.EmployerPartPayment = employerPartPaymentFinal;
+            calculationResult.NetEntitlement = netEntitlementFinal;
             calculationResult.PreferentialClaim = 0m;
-            calculationResult.NonPreferentialClaim = Math.Max(0m, Math.Round(grossEntitlement, 2) - Math.Round(data.EmployerPartPayment, 2));
+            calculationResult.NonPreferentialClaim = grossEntitlementFinal;
+            calculationResult.StatutoryMaximum = statutoryMax;
             return calculationResult;
         }
     }


### PR DESCRIPTION
Fixed bug where the grossEntitlement returned from the calculation was always the same as the netEntitlement.
The outputs from the RP (Redundancy Pay calculation need to include the Statutory Maximum used in the calculation.
Update unit test to reflect change made to gross and net entitlement above.