### PR TITLE
RCA-325 - Update validation message

### DIFF
--- a/Insolvency.CalculationsEngine.Redundancy.API.UnitTests/TestData/NoticeValidationTestDataHelper.cs
+++ b/Insolvency.CalculationsEngine.Redundancy.API.UnitTests/TestData/NoticeValidationTestDataHelper.cs
@@ -132,7 +132,7 @@ namespace Insolvency.CalculationsEngine.Redundancy.API.UnitTests.TestData
                         }
                     }
                 },
-                "Notice Worked Not Paid RP1 data has been not provided" };
+                "Notice Worked Not Paid RP1 data has not been provided" };
         }
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();

--- a/Insolvency.CalculationsEngine.Redundancy.API/Infrastructure/Middlewares/Validators/NoticePayCompositeCalculationRequestValidator.cs
+++ b/Insolvency.CalculationsEngine.Redundancy.API/Infrastructure/Middlewares/Validators/NoticePayCompositeCalculationRequestValidator.cs
@@ -33,7 +33,7 @@ namespace Insolvency.CalculationsEngine.Redundancy.API.Infrastructure.Middleware
 
             RuleFor(req => req)
                .Must(RP1DataPresent)
-               .WithMessage($"Notice Worked Not Paid RP1 data has been not provided")
+               .WithMessage($"Notice Worked Not Paid RP1 data has not been provided")
                .When(req => req.Nwnp != null);
         }
 


### PR DESCRIPTION
When RP1 data has not been provided for the notice endpoint it currently reads:

"Notice Worked Not Paid RP1 data has been not provided"

It needs to read

"Notice Worked Not Paid RP1 data has not been provided"