### PR TITLE
Fcgh 150

### DIFF
--- a/Insolvency.CalculationsEngine.Redundancy.BL.UnitTests/ServicesTests/ArrearsOfPayCalculationsServiceTests.cs
+++ b/Insolvency.CalculationsEngine.Redundancy.BL.UnitTests/ServicesTests/ArrearsOfPayCalculationsServiceTests.cs
@@ -255,7 +255,7 @@ namespace Insolvency.CalculationsEngine.Redundancy.BL.UnitTests.ServicesTests
             var expectedCalculationResult = new ArrearsOfPayResponseDTO(InputSource.Rp1, 508M, true, false, weeklyResult: new List<ArrearsOfPayWeeklyResult>()
                 {
                     new ArrearsOfPayWeeklyResult(1, new DateTime(2018, 10, 13),350M, 508M, 350M, 350M,true,70M, 22.08M, 257.92M,7, 5, 508M, 350M, 350M),
-                    new ArrearsOfPayWeeklyResult(2, new DateTime(2018, 10, 20),350M, 508M, 350M, 350M,true,70M, 22.08M, 257.92M, 7, 5, 508M, 350M, 350M),
+                    new ArrearsOfPayWeeklyResult(2, new DateTime(2018, 10, 20),350M, 508M, 0M, 0M,true, 0M, 0M, 0M, 7, 5, 508M, 350M, 350M),
                 });
 
             var actualResult = await _arrearsOfPayCalculationsService.PerformCalculationAsync(aopRequest, _options);

--- a/Insolvency.CalculationsEngine.Redundancy.BL/Services/Implementations/ArrearsOfPayCalculationsService.cs
+++ b/Insolvency.CalculationsEngine.Redundancy.BL/Services/Implementations/ArrearsOfPayCalculationsService.cs
@@ -50,11 +50,9 @@ namespace Insolvency.CalculationsEngine.Redundancy.BL.Services.Implementations
             var payDays = await adjustedPeriodFrom.Date.GetDaysInRange(extendedAdjustedPeriodTo.Date, (DayOfWeek)data.PayDay);
 
             decimal adjustedWeeklyWage = await data.WeeklyWage.GetAdjustedWeeklyWageAsync(data.ShiftPattern, adjustedPeriodFrom, adjustedPeriodTo, data.ApClaimAmount);
-            decimal WeeklyWageBetweenNoticeGivenAndNoticeEnd = adjustedWeeklyWage - data.WeeklyWage;
+            decimal WeeklyWageBetweenNoticeGivenAndNoticeEnd = (adjustedWeeklyWage > data.WeeklyWage) ?  adjustedWeeklyWage - data.WeeklyWage : decimal.Zero;
             decimal postDNGAdjustedWeeklyWage = (adjustedWeeklyWage >= data.WeeklyWage) ? adjustedWeeklyWage - data.WeeklyWage : adjustedWeeklyWage;
-            //decimal postDNGAdjustedWeeklyWage = adjustedWeeklyWage - data.WeeklyWage;
-            //decimal postDNEAdjustedWeeklyWage = adjustedWeeklyWage;
-
+            
             DateTime prefPeriodStartDate = data.InsolvencyDate.Date.AddMonths(-4);
             prefPeriodStartDate = (prefPeriodStartDate <= data.EmploymentStartDate.Date) ? data.EmploymentStartDate.Date : prefPeriodStartDate.Date;
             DateTime prefPeriodEndDate = (data.DismissalDate < data.InsolvencyDate) ? data.DismissalDate.Date : data.InsolvencyDate.Date;

--- a/Insolvency.CalculationsEngine.Redundancy.BL/Services/Implementations/ArrearsOfPayCalculationsService.cs
+++ b/Insolvency.CalculationsEngine.Redundancy.BL/Services/Implementations/ArrearsOfPayCalculationsService.cs
@@ -10,6 +10,7 @@ using Insolvency.CalculationsEngine.Redundancy.Common.Extensions;
 using Microsoft.Extensions.Options;
 using Insolvency.CalculationsEngine.Redundancy.Common.ConfigLookups;
 using Insolvency.CalculationsEngine.Redundancy.Common.Exceptions;
+using Insolvency.CalculationsEngine.Redundancy.BL.Calculations.RedundancyPaymentCalculation.Extensions;
 
 namespace Insolvency.CalculationsEngine.Redundancy.BL.Services.Implementations
 {
@@ -34,6 +35,12 @@ namespace Insolvency.CalculationsEngine.Redundancy.BL.Services.Implementations
             int weekNumber = 1;
 
             var statutoryMax = ConfigValueLookupHelper.GetStatutoryMax(options, data.DismissalDate);
+
+            var relevantNoticeDate = await data.DateNoticeGiven.GetRelevantNoticeDate(data.DismissalDate);
+            var noticeEntitlementWeeks = await data.EmploymentStartDate.GetNoticeEntitlementWeeks(relevantNoticeDate);    //not adjusted start date      
+            var projectedNoticeEndDate = await relevantNoticeDate.GetProjectedNoticeDate(noticeEntitlementWeeks);
+
+
             var adjustedPeriodFrom = await data.UnpaidPeriodFrom.Date.GetAdjustedPeriodFromAsync(data.InsolvencyDate.Date);
             var adjustedPeriodTo = await data.UnpaidPeriodTo.Date.GetAdjustedPeriodToAsync(data.InsolvencyDate.Date, data.DismissalDate.Date);
            
@@ -43,7 +50,10 @@ namespace Insolvency.CalculationsEngine.Redundancy.BL.Services.Implementations
             var payDays = await adjustedPeriodFrom.Date.GetDaysInRange(extendedAdjustedPeriodTo.Date, (DayOfWeek)data.PayDay);
 
             decimal adjustedWeeklyWage = await data.WeeklyWage.GetAdjustedWeeklyWageAsync(data.ShiftPattern, adjustedPeriodFrom, adjustedPeriodTo, data.ApClaimAmount);
+            decimal WeeklyWageBetweenNoticeGivenAndNoticeEnd = adjustedWeeklyWage - data.WeeklyWage;
             decimal postDNGAdjustedWeeklyWage = (adjustedWeeklyWage >= data.WeeklyWage) ? adjustedWeeklyWage - data.WeeklyWage : adjustedWeeklyWage;
+            //decimal postDNGAdjustedWeeklyWage = adjustedWeeklyWage - data.WeeklyWage;
+            //decimal postDNEAdjustedWeeklyWage = adjustedWeeklyWage;
 
             DateTime prefPeriodStartDate = data.InsolvencyDate.Date.AddMonths(-4);
             prefPeriodStartDate = (prefPeriodStartDate <= data.EmploymentStartDate.Date) ? data.EmploymentStartDate.Date : prefPeriodStartDate.Date;
@@ -53,7 +63,7 @@ namespace Insolvency.CalculationsEngine.Redundancy.BL.Services.Implementations
             foreach (var payWeekEnd in payDays)
             {
                 var employmentDays = 0;
-                var employmentDaysPostDNG = 0;
+                var employmentDaysBetweenNoticeGivenAndNoticeEndDate = 0;               
                 var maximumEntitlement = 0.0m;
                 var employmentDaysInPrefPeriod = 0;
                 var employmentDaysInPrefPeriodPostDNG = 0;
@@ -66,16 +76,18 @@ namespace Insolvency.CalculationsEngine.Redundancy.BL.Services.Implementations
 
                     //is this day a working day?
                     if (await date.IsEmploymentDay(data.ShiftPattern))
-                    {
+                    {                        
+
                         if (date >= adjustedPeriodFrom.Date && date <= adjustedPeriodTo.Date)
                         {
-                            if (date > data.DateNoticeGiven.Date)
+                            if (date >= data.DateNoticeGiven.Date && date <= projectedNoticeEndDate.Date)
                             {
-                                employmentDaysPostDNG++;
+                                employmentDaysBetweenNoticeGivenAndNoticeEndDate++;
 
                                 if (date >= prefPeriodStartDate && date <= prefPeriodEndDate)
                                     employmentDaysInPrefPeriodPostDNG++;
                             }
+                           
                             else
                             {
                                 employmentDays++;
@@ -93,7 +105,7 @@ namespace Insolvency.CalculationsEngine.Redundancy.BL.Services.Implementations
 
                 //calculate Employer Liability for week
                 var employerEntitlement = adjustedWeeklyWage / data.ShiftPattern.Count * employmentDays +
-                                            postDNGAdjustedWeeklyWage / data.ShiftPattern.Count * employmentDaysPostDNG;
+                                            WeeklyWageBetweenNoticeGivenAndNoticeEnd / data.ShiftPattern.Count * employmentDaysBetweenNoticeGivenAndNoticeEndDate;
 
                 employerEntitlementInPrefPeriod = adjustedWeeklyWage / data.ShiftPattern.Count * employmentDaysInPrefPeriod +
                                                     postDNGAdjustedWeeklyWage / data.ShiftPattern.Count * employmentDaysInPrefPeriodPostDNG;


### PR DESCRIPTION
Implement the following rule in AOP calculation:

Period between claim period from and DNG:

This is calculated based on the Applied Weekly Wage.

Period between Projected Notice Date and Claim period to date:

This is calculated based on the Applied Weekly Wage

Period between Date Notice Given and Projected Notice date:

If the Applied weekly wage is greater than the weekly wage, Applied weekly wage - weekly wage.

If the Applied weekly wage = weekly wage then the ap payment is zero.

If the Applied Weekly Wage is less than the weekly wage, then the ap payment is zero.