### PR TITLE
ASP-157: Fix for HPNT to include all periods in trace

### DIFF
--- a/Insolvency.CalculationsEngine.Redundancy.BL/Services/Implementations/HolidayTakenNotPaidCalculationService.cs
+++ b/Insolvency.CalculationsEngine.Redundancy.BL/Services/Implementations/HolidayTakenNotPaidCalculationService.cs
@@ -107,12 +107,12 @@ namespace Insolvency.CalculationsEngine.Redundancy.BL.Services.Implementations
                         GrossEntitlementIn4Months = Math.Round(Math.Min(maximumEntitlementInPrefPeriod, employerEntitlementInPrefPeriod), 2),
                     });
                 }
-             
-                traceInfo?.Dates.Add(new TraceInfoDate
-                {
-                    StartDate = firstRequest.UnpaidPeriodFrom,
-                    EndDate = firstRequest.UnpaidPeriodTo
-                }); ;
+                foreach (var req in data.Where(x => x.InputSource == inputSource))
+                    traceInfo?.Dates.Add(new TraceInfoDate
+                    {
+                       StartDate = req.UnpaidPeriodFrom,
+                       EndDate = req.UnpaidPeriodTo
+                   });
             }
             return await Task.FromResult(calculationResult);
         }


### PR DESCRIPTION
This includes all user-supplied periods in the trace, not just the first one. Uses user-supplied rather than calculated, to avoid any confusion around working patterns for people on variable shift patterns and those not paid weekly.