### PR TITLE
Calc Engine - HPT calculation without RP14a

### DIFF
--- a/Insolvency.CalculationsEngine.Redundancy.API.UnitTests/ControllersTests/HolidayControllerTests.cs
+++ b/Insolvency.CalculationsEngine.Redundancy.API.UnitTests/ControllersTests/HolidayControllerTests.cs
@@ -312,6 +312,19 @@ namespace Insolvency.CalculationsEngine.Redundancy.API.UnitTests.ControllersTest
                         PayDay = 6,
                         IsTaxable = true
                     },
+
+                     new HolidayTakenNotPaidCalculationRequestModel()
+                    {
+                        InputSource = InputSource.Rp1,
+                        InsolvencyDate = new DateTime(2018, 01, 10),
+                        DismissalDate = new DateTime(2018, 01, 03),
+                        UnpaidPeriodFrom = new DateTime(2017, 12, 12),
+                        UnpaidPeriodTo = new DateTime(2017, 12, 29),
+                        WeeklyWage = 306.85m,
+                        ShiftPattern = new List<string> { "1", "2", "3", "4", "5" },
+                        PayDay = 6,
+                        IsTaxable = true
+                    }
                 }
             };
             var response = new HolidayCalculationResponseDTO();

--- a/Insolvency.CalculationsEngine.Redundancy.API.UnitTests/TestData/HolidayControllerTestsDataGenerator.cs
+++ b/Insolvency.CalculationsEngine.Redundancy.API.UnitTests/TestData/HolidayControllerTestsDataGenerator.cs
@@ -11,6 +11,8 @@ namespace Insolvency.CalculationsEngine.Redundancy.API.UnitTests.TestData
         {
             return new HolidayCalculationRequestModel()
             {
+                Rp1NotRequired = true,
+                Rp14aNotRequired= true,
                 Hpa = new HolidayPayAccruedCalculationRequestModel
                 {
                     InsolvencyDate = new DateTime(2017, 03, 22),

--- a/Insolvency.CalculationsEngine.Redundancy.API.UnitTests/TestData/HolidayValidationTestDataHelper.cs
+++ b/Insolvency.CalculationsEngine.Redundancy.API.UnitTests/TestData/HolidayValidationTestDataHelper.cs
@@ -51,7 +51,8 @@ namespace Insolvency.CalculationsEngine.Redundancy.API.UnitTests.TestData
             yield return new object[] {
                 new HolidayCalculationRequestModel
                 {
-                    Rp14aNotRequired = false,
+                    Rp14aNotRequired = true,
+                    Rp1NotRequired = false,
                     Hpa = new HolidayPayAccruedCalculationRequestModel
                     {
                         InsolvencyDate = new DateTime(2017, 03, 22),
@@ -88,6 +89,7 @@ namespace Insolvency.CalculationsEngine.Redundancy.API.UnitTests.TestData
                 new HolidayCalculationRequestModel
                 {
                     Rp14aNotRequired = false,
+                    Rp1NotRequired = true,
                     Hpa = new HolidayPayAccruedCalculationRequestModel
                     {
                         InsolvencyDate = new DateTime(2017, 03, 22),

--- a/Insolvency.CalculationsEngine.Redundancy.API/Infrastructure/Middlewares/Validators/HolidayCalculationRequestValidator.cs
+++ b/Insolvency.CalculationsEngine.Redundancy.API/Infrastructure/Middlewares/Validators/HolidayCalculationRequestValidator.cs
@@ -69,16 +69,12 @@ namespace Insolvency.CalculationsEngine.Redundancy.API.Infrastructure.Middleware
 
         private bool RP1DataPresent(HolidayCalculationRequestModel data)
         {
-            return data.Htnp.Count(x => x.InputSource == InputSource.Rp14a) == 0 ||
-                data.Htnp.Count(x => x.InputSource == InputSource.Rp1) > 0 ||
-                data.Rp1NotRequired;
+            return data.Rp14aNotRequired ? data.Htnp.Count(x => x.InputSource == InputSource.Rp1) > 0 : true;
         }
 
         private bool RP14aDataPresent(HolidayCalculationRequestModel data)
         {
-            return data.Htnp.Count(x => x.InputSource == InputSource.Rp1) == 0 ||
-                data.Htnp.Count(x => x.InputSource == InputSource.Rp14a) > 0 ||
-                data.Rp14aNotRequired;
+            return data.Rp1NotRequired ? data.Htnp.Count(x => x.InputSource == InputSource.Rp14a) > 0 : true;
         }
     }
 }


### PR DESCRIPTION
When the "No RP14a required" box is ticked, it should use the data present from the RP1 and not RP14a