### PR TITLE
ASP-179: Add NumberOfDays to trace info

### DIFF
--- a/Insolvency.CalculationsEngine.Redundancy.BL/Services/Implementations/ArrearsOfPayCalculationsService.cs
+++ b/Insolvency.CalculationsEngine.Redundancy.BL/Services/Implementations/ArrearsOfPayCalculationsService.cs
@@ -32,6 +32,7 @@ namespace Insolvency.CalculationsEngine.Redundancy.BL.Services.Implementations
             var calculationResult = new ArrearsOfPayResponseDTO();
             var weeklyresult = new List<ArrearsOfPayWeeklyResult>();
             int weekNumber = 1;
+            var totalDays = 0.00m;
 
             var statutoryMax = ConfigValueLookupHelper.GetStatutoryMax(options, data.DismissalDate);
 
@@ -140,6 +141,7 @@ namespace Insolvency.CalculationsEngine.Redundancy.BL.Services.Implementations
                     EmployerEntitlementIn4MonthPeriod = employerEntitlementInPrefPeriod,
                     GrossEntitlementIn4Months = Math.Min(maximumEntitlementInPrefPeriod, employerEntitlementInPrefPeriod)
                 });
+                totalDays += employmentDays + employmentDaysInPrefPeriodPostDNG;
             } //outter loop for paydays collection
 
             calculationResult.InputSource = data.InputSource;
@@ -152,6 +154,8 @@ namespace Insolvency.CalculationsEngine.Redundancy.BL.Services.Implementations
                 StartDate = data.UnpaidPeriodFrom,
                 EndDate = data.UnpaidPeriodTo
             });
+            if (traceInfo != null)
+                traceInfo.NumberOfDays = totalDays;
 
             return await Task.FromResult(calculationResult);
         }

--- a/Insolvency.CalculationsEngine.Redundancy.BL/Services/Implementations/HolidayTakenNotPaidCalculationService.cs
+++ b/Insolvency.CalculationsEngine.Redundancy.BL/Services/Implementations/HolidayTakenNotPaidCalculationService.cs
@@ -65,6 +65,7 @@ namespace Insolvency.CalculationsEngine.Redundancy.BL.Services.Implementations
 
                 // generate the output weeks
                 int weekNum = 1;
+                decimal total_days = 0.00m;
 
                 foreach (var week in weeks.OrderBy(x => x.PayDate).ThenBy(x => x.IsSelected))
                 {
@@ -88,6 +89,7 @@ namespace Insolvency.CalculationsEngine.Redundancy.BL.Services.Implementations
                     grossEntitlement = Math.Round(grossEntitlement, 2);
                     var netLiability = await grossEntitlement.GetNetLiability(taxDeducated, niDeducted);
 
+                    total_days += week.EmploymentDays;
                     calculationResult.WeeklyResult.Add(new HolidayTakenNotPaidWeeklyResult()
                     {
                         WeekNumber = weekNum++,
@@ -111,8 +113,10 @@ namespace Insolvency.CalculationsEngine.Redundancy.BL.Services.Implementations
                     traceInfo?.Dates.Add(new TraceInfoDate
                     {
                        StartDate = req.UnpaidPeriodFrom,
-                       EndDate = req.UnpaidPeriodTo
-                   });
+                       EndDate = req.UnpaidPeriodTo,
+                    });
+                if (traceInfo != null)
+                    traceInfo.NumberOfDays = total_days;
             }
             return await Task.FromResult(calculationResult);
         }

--- a/Insolvency.CalculationsEngine.Redundancy.BL/Services/Implementations/NoticePayCompositeCalculationService.cs
+++ b/Insolvency.CalculationsEngine.Redundancy.BL/Services/Implementations/NoticePayCompositeCalculationService.cs
@@ -58,12 +58,18 @@ namespace Insolvency.CalculationsEngine.Redundancy.BL.Services.Implementations
                         //nwnpOutput.nwnpResults.rP1ResultsList.Add(res);
                         nwnpOutput.rp1Results.WeeklyResult.AddRange(res.WeeklyResult);
                         rp1TraceInfo.Dates.Add(traceDate);
+                        rp1TraceInfo.NumberOfDays = 0.00m;
+                        foreach (var week in res.WeeklyResult)
+                            rp1TraceInfo.NumberOfDays += week.EmploymentDays;
                     }
                     else if (res.InputSource == InputSource.Rp14a)
                     {
                         //nwnpOutput.nwnpResults.rP14aResultsList.Add(res);
                         nwnpOutput.rp14aResults.WeeklyResult.AddRange(res.WeeklyResult);
                         rp14TraceInfo.Dates.Add(traceDate);
+                        rp14TraceInfo.NumberOfDays = 0.00m;
+                        foreach (var week in res.WeeklyResult)
+                            rp14TraceInfo.NumberOfDays += week.EmploymentDays;
                     }
                 }
 

--- a/Insolvency.CalculationsEngine.Redundancy.Common/ConfigLookups/TraceInfo.cs
+++ b/Insolvency.CalculationsEngine.Redundancy.Common/ConfigLookups/TraceInfo.cs
@@ -14,6 +14,9 @@ namespace Insolvency.CalculationsEngine.Redundancy.Common.ConfigLookups
 
         [JsonProperty("dates")]
         public IList<TraceInfoDate> Dates { get; set; }
-     
+
+        [JsonProperty("NumberOfDays")]
+        public Decimal NumberOfDays { get; set; }
+
     }
 }


### PR DESCRIPTION
The calculations that already return date ranges should also return
a total number of days. This is sometimes available through other
means, but this guarantees it as it's not consistent.